### PR TITLE
Revert escape characters of csv payload

### DIFF
--- a/src/main/java/org/wso2/carbon/module/core/SimpleMessageContext.java
+++ b/src/main/java/org/wso2/carbon/module/core/SimpleMessageContext.java
@@ -772,7 +772,7 @@ public final class SimpleMessageContext {
 
         String csvText;
         if (payloadText != null) {
-            csvText = payloadText;
+            csvText = StringEscapeUtils.unescapeXml(payloadText);
         } else {
             log.error("Error converting data : not a valid CSV payload");
             csvText = "";


### PR DESCRIPTION
## Description
- Currently in the CSV connector, when trying to convert CSV to JSON, commas between double quotes (") are being treated as separators.
- According to the [CSV specifications](https://datatracker.ietf.org/doc/html/rfc4180) if a field is enclosed with double quotes, commas inside of that field should not be considered as separators.

## Approach
- Due to double quotes have been escaped using xml entities, commas inside the enclosed field are identified as separators.
- In this PR the payload string is reverted to have the escaped characters from xml entities to the original state.

## Related Issues
- Public Git Issue : https://github.com/wso2/api-manager/issues/852


